### PR TITLE
Fixed some inconsistences.

### DIFF
--- a/pcap2sipp/pcap_helper.py
+++ b/pcap2sipp/pcap_helper.py
@@ -8,7 +8,7 @@ def parsePcap(pcap):
 
 def isCallIdInPacket(packet, callid):
     sipMsg = packet.load.lower().decode('utf-8')
-    return True if re.search(r'\r\ncall-id:.*{}\r\n'.format(callid), sipMsg) else False
+    return True if re.search(r'\r\ncall-id:.*{}.*\r\n'.format(callid), sipMsg) else False
 
 def filterPacketsByCallid(packets, callid):
     filteredPackets = []

--- a/pcap2sipp/sipp_helper.py
+++ b/pcap2sipp/sipp_helper.py
@@ -98,7 +98,7 @@ def parseFirstLineFrom(sipMsg):
 
 
 def getSipMsgAndDirection(packetInfo):
-    sipMsg = packetInfo.packet.load.lower().decode('utf-8')
+    sipMsg = packetInfo.packet.load.decode('utf-8')
     direction = packetInfo.direction
     return sipMsg, direction
 


### PR DESCRIPTION
1. SIPP scenario should have original case
2. callid filter doesn't work and re.escape couldn't make a proper regular expression if callid has special metasymbols